### PR TITLE
Register plugin to rasterio.rio_plugins instead of directly to the main rio command group

### DIFF
--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -5,12 +5,11 @@ import math
 from multiprocessing import cpu_count, Pool
 import os
 import sqlite3
-import sys
 
 import click
 import mercantile
 import rasterio
-from rasterio.rio.cli import cli, output_opt, resolve_inout
+from rasterio.rio.helpers import resolve_inout
 from rasterio.warp import transform
 
 from mbtiles import buffer, init_worker, process_tile
@@ -20,7 +19,7 @@ from mbtiles import __version__ as mbtiles_version
 DEFAULT_NUM_WORKERS = cpu_count() - 1
 
 
-@cli.command(short_help="Export a dataset to MBTiles.")
+@click.command(short_help="Export a dataset to MBTiles.")
 @click.argument(
     'files',
     nargs=-1,
@@ -191,5 +190,3 @@ def mbtiles(ctx, files, output_opt, title, description, layer_type,
 
         conn.close()
         # Done!
-
-        sys.exit(0)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='rio-mbtiles',
           'test': ['pytest'],
       },
       entry_points="""
-      [rasterio.rio_commands]
-      mbtiles=mbtiles.scripts.cli:cli
+      [rasterio.rio_plugins]
+      mbtiles=mbtiles.scripts.cli:mbtiles
       """
       )


### PR DESCRIPTION
@sgillies I tried using this plugin to validate the rasterio changes in https://github.com/mapbox/rasterio/pull/374 and noticed the plugin was both decorated with the main `rio` group and registering to the `rasterio.rio_commands` entry-point so I made it a simple `click.Command()` and registered it to `rasterio.rio_plugins`.

The `setup.py` will need to be updated before release to require the right version of rasterio.  Changing it in this PR would have prevented Travis from testing.