### PR TITLE
Use rasterio travis wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libgdal1h gdal-bin
   - curl -L https://github.com/mapbox/rasterio/releases/download/release-test-3/rasterio-travis-wheels-2.7.tar.gz > /tmp/wheelhouse.tar.gz
-  - tar -xzvf wheelhouse.tar.gz -C $HOME
+  - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
 install:
   - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ python:
 cache:
   directories:
     - $HOME/.pip-cache/
+    - $HOME/wheelhouse
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update -qq
-  - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
-  - wget https://s3.amazonaws.com/mapbox/rasterio/rasterio-0.25.0-$TRAVIS_PYTHON_VERSION-linux-x86_64.tar.gz
-  - tar xzf rasterio-0.25.0-$TRAVIS_PYTHON_VERSION-linux-x86_64.tar.gz
-  - ./.travis-install-platter.sh /home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION
+  - sudo apt-get install -y libgdal1h gdal-bin
+  - curl -L https://github.com/mapbox/rasterio/releases/download/release-test-3/rasterio-travis-wheels-2.7.tar.gz > /tmp/wheelhouse.tar.gz
+  - tar -xzvf wheelhouse.tar.gz -C $HOME
 install:
-  - pip install -e .[test] --cache-dir $HOME/.pip-cache
+  - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache
 script:
   - py.test --cov mbtiles --cov-report term-missing
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update -qq
   - sudo apt-get install -y libgdal1h gdal-bin
-  - curl -L https://github.com/mapbox/rasterio/releases/download/release-test-3/rasterio-travis-wheels-2.7.tar.gz > /tmp/wheelhouse.tar.gz
+  - curl -L https://github.com/mapbox/rasterio/releases/download/release-test-4/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
   - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
 install:
   - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='rio-mbtiles',
           'rasterio>=0.23'
       ],
       extras_require={
-          'test': ['pytest', 'pytest-cov'],
+          'test': ['coveralls', 'pytest', 'pytest-cov'],
       },
       entry_points="""
       [rasterio.rio_plugins]


### PR DESCRIPTION
This PR gets the matrix of builds down from 3 mins to less than a minute.

It does add a need to maintain a URL in Travis to the release tarball.

Closes #10.