### PR TITLE
WIP: Update rasterio version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ cache:
   directories:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
-#before_install:
-#  - "./.travis_riodeps.sh"
+before_install:
+  - "./.travis_riodeps.sh"
 install:
   - "pip install -U pip"
   - "pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ cache:
   directories:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
-before_install:
-  - "./.travis_riodeps.sh"
+#before_install:
+#  - "./.travis_riodeps.sh"
 install:
   - "pip install -U pip"
   - "pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-sudo: false
 language: python
 env:
-  - RASTERIO_VERSION=0.26.0
+  - RASTERIO_VERSION=0.36.0
 addons:
   apt:
     packages:
@@ -10,6 +9,7 @@ addons:
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -55,10 +55,15 @@ DEFAULT_NUM_WORKERS = cpu_count() - 1
 @click.option('-j', 'num_workers', type=int, default=DEFAULT_NUM_WORKERS,
               help="Number of worker processes (default: %d)." % (
                   DEFAULT_NUM_WORKERS))
+@click.option(
+    '--force-overwrite', 'force_overwrite',
+    is_flag=True, type=bool, default=False,
+    help="Always overwrite an existing output file.")
 @click.version_option(version=mbtiles_version, message='%(version)s')
 @click.pass_context
 def mbtiles(ctx, files, output_opt, title, description, layer_type,
-            img_format, zoom_levels, image_dump, num_workers):
+            img_format, zoom_levels, image_dump, num_workers,
+            force_overwrite):
     """Export a dataset to MBTiles (version 1.1) in a SQLite file.
 
     The input dataset may have any coordinate reference system. It must
@@ -80,10 +85,11 @@ def mbtiles(ctx, files, output_opt, title, description, layer_type,
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
 
-    output, files = resolve_inout(files=files, output=output_opt)
+    output, files = resolve_inout(files=files, output=output_opt,
+                                  force_overwrite=force_overwrite)
     inputfile = files[0]
 
-    with rasterio.drivers(CPL_DEBUG=verbosity > 2):
+    with rasterio.Env(CPL_DEBUG=(verbosity > 2)):
 
         # Read metadata from the source dataset.
         with rasterio.open(inputfile) as src:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ cython==0.21.2
 enum34
 numpy>=1.8.0
 pytest
-rasterio>=0.23
+rasterio>=0.36
 snuggs>=1.2
 setuptools>=0.9.8

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='rio-mbtiles',
       install_requires=[
           'click',
           'mercantile',
-          'rasterio>=0.23'
+          'rasterio>=0.36'
       ],
       extras_require={
           'test': ['coveralls', 'pytest', 'pytest-cov'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import sys
 
-import py
 import pytest
 from click.testing import CliRunner
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 
 import py
 import pytest
-import rasterio
+from click.testing import CliRunner
 
 
 if sys.version_info > (3,):
@@ -26,10 +26,16 @@ def pytest_cmdline_main(config):
         sys.exit(1)
 
 
-@pytest.fixture(scope='function')
-def data():
+@pytest.fixture
+def data(tmpdir):
     """A temporary directory containing a copy of the files in data."""
-    tmpdir = py.test.ensuretemp('tests/data')
+    tmpdir = tmpdir.join('tests/data')
+    os.makedirs(str(tmpdir))
     for filename in test_files:
         shutil.copy(filename, str(tmpdir))
     return tmpdir
+
+
+@pytest.fixture(scope='function')
+def runner():
+    return CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,27 +3,25 @@ import os
 import sqlite3
 import sys
 
-from click.testing import CliRunner
 import pytest
-import rasterio
 
 from mbtiles.scripts.cli import mbtiles
 
+# logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_cli_help():
-    runner = CliRunner()
+
+
+def test_cli_help(runner):
     result = runner.invoke(mbtiles, ['--help'])
     assert result.exit_code == 0
     assert "Export a dataset to MBTiles (version 1.1)" in result.output
 
 
-def test_export_metadata(data):
+def test_export_metadata(runner, data):
     inputfile = str(data.join('RGB.byte.tif'))
     outputfile = str(data.join('export.mbtiles'))
-    runner = CliRunner()
     result = runner.invoke(mbtiles, [inputfile, outputfile])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
@@ -32,10 +30,9 @@ def test_export_metadata(data):
     assert cur.fetchone()[1] == 'RGB.byte.tif'
 
 
-def test_export_metadata_output_opt(data):
+def test_export_metadata_output_opt(runner, data):
     inputfile = str(data.join('RGB.byte.tif'))
     outputfile = str(data.join('export.mbtiles'))
-    runner = CliRunner()
     result = runner.invoke(mbtiles, [inputfile, '-o', outputfile])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
@@ -44,10 +41,34 @@ def test_export_metadata_output_opt(data):
     assert cur.fetchone()[1] == 'RGB.byte.tif'
 
 
-def test_export_tiles(data):
+def test_export_metadata_output_existing_output(runner, data):
     inputfile = str(data.join('RGB.byte.tif'))
     outputfile = str(data.join('export.mbtiles'))
-    runner = CliRunner()
+    result = runner.invoke(mbtiles, [inputfile, outputfile])
+    assert result.exit_code == 0
+    assert os.path.exists(outputfile)
+
+    result = runner.invoke(mbtiles, [inputfile, outputfile])
+    assert result.exit_code == 1
+    assert "file exists and won't be overwritten " in result.output
+
+
+def test_export_metadata_output_force_overwrite(runner, data):
+    inputfile = str(data.join('RGB.byte.tif'))
+    outputfile = str(data.join('export.mbtiles'))
+    result = runner.invoke(mbtiles, [inputfile, outputfile])
+    assert result.exit_code == 0
+    assert os.path.exists(outputfile)
+
+    result = runner.invoke(mbtiles, [inputfile, outputfile,
+                                     '--force-overwrite'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputfile)
+
+
+def test_export_tiles(runner, data):
+    inputfile = str(data.join('RGB.byte.tif'))
+    outputfile = str(data.join('export.mbtiles'))
     result = runner.invoke(mbtiles, [inputfile, outputfile])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
@@ -56,10 +77,9 @@ def test_export_tiles(data):
     assert len(cur.fetchall()) == 6
 
 
-def test_export_zoom(data):
+def test_export_zoom(runner, data):
     inputfile = str(data.join('RGB.byte.tif'))
     outputfile = str(data.join('export.mbtiles'))
-    runner = CliRunner()
     result = runner.invoke(
         mbtiles, [inputfile, outputfile, '--zoom-levels', '6..7'])
     assert result.exit_code == 0
@@ -69,10 +89,9 @@ def test_export_zoom(data):
     assert len(cur.fetchall()) == 6
 
 
-def test_export_jobs(data):
+def test_export_jobs(runner, data):
     inputfile = str(data.join('RGB.byte.tif'))
     outputfile = str(data.join('export.mbtiles'))
-    runner = CliRunner()
     result = runner.invoke(
         mbtiles, [inputfile, outputfile, '-j', '4'])
     assert result.exit_code == 0
@@ -82,11 +101,10 @@ def test_export_jobs(data):
     assert len(cur.fetchall()) == 6
 
 
-def test_export_dump(data):
+def test_export_dump(runner, data):
     inputfile = str(data.join('RGB.byte.tif'))
     outputfile = str(data.join('export.mbtiles'))
     dumpdir = pytest.ensuretemp('dump')
-    runner = CliRunner()
     result = runner.invoke(
         mbtiles, [inputfile, outputfile, '--image-dump', str(dumpdir)])
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,7 @@ import pytest
 
 from mbtiles.scripts.cli import mbtiles
 
-# logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
-
-
-
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 def test_cli_help(runner):


### PR DESCRIPTION
This attempts to update to a more recent version of rasterio.  Tested against rasterio `master` branch.

This fixes:
* use of `rasterio.Env()`
* updated output option that does not automatically overwrite existing output
* issues with previous `data` fixture that was keeping prior outputs around between tests

This adds:
* `--force-overwrite` from rasterio, and appropriate tests

This does not run on Travis because there is no available release wheel after 0.32.0.post1