### PR TITLE
Add resampling option

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,3 +129,17 @@ def test_export_dump(tmpdir, data):
         ['mbtiles', inputfile, outputfile, '--image-dump', str(dumpdir)])
     assert result.exit_code == 0
     assert len(os.listdir(str(dumpdir))) == 6
+
+
+def test_export_bilinear(tmpdir, data):
+    inputfile = str(data.join('RGB.byte.tif'))
+    outputfile = str(tmpdir.join('export.mbtiles'))
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['mbtiles', inputfile, outputfile, '--resampling', 'bilinear'])
+    assert result.exit_code == 0
+    conn = sqlite3.connect(outputfile)
+    cur = conn.cursor()
+    cur.execute("select * from tiles")
+    assert len(cur.fetchall()) == 6

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -12,7 +12,8 @@ def test_process_tile(data):
             'height': 256,
             'width': 256,
             'count': 3,
-            'crs': 'EPSG:3857'})
+            'crs': 'EPSG:3857'},
+            "nearest")
     tile, contents = mbtiles.process_tile(mercantile.Tile(36, 73, 7))
     assert tile.x == 36
     assert tile.y == 73


### PR DESCRIPTION
This exposes the resampling methods in `rasterio` as options to use during the reprojection step in creating tiles from a raster. Possibly a subset of these would be sufficient for typical uses. Certainly the help text is a little much as is.

I tried to add this in a way that was consistent with the existing style, so please let me know if I've gone astray. 