### PR TITLE
skip processing empty tiles

### DIFF
--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -5,7 +5,7 @@ import rasterio
 from rasterio.enums import Resampling
 from rasterio.transform import from_bounds as transform_from_bounds
 from rasterio.windows import from_bounds as window_from_bounds
-from rasterio.warp import reproject, transform_bounds, transform
+from rasterio.warp import reproject, transform_bounds
 from rasterio._io import virtual_file_to_buffer
 
 

--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -16,6 +16,8 @@ __version__ = '1.3.0'
 base_kwds = None
 src = None
 
+TILES_CRS = 'EPSG:3857'
+
 
 def init_worker(path, profile, resampling_method):
     global base_kwds, src, resampling
@@ -51,8 +53,10 @@ def process_tile(tile):
 
     with rasterio.open('/vsimem/tileimg', 'w', **kwds) as tmp:
 
+        # determine window of source raster corresponding to the tile
+        # image, with small buffer at edges
         west, south, east, north = transform_bounds(
-                             "EPSG:3857", src.crs, ulx, lry, lrx, uly)
+                             TILES_CRS, src.crs, ulx, lry, lrx, uly)
         tile_window = window_from_bounds(
                 west, south, east, north, transform=src.transform)
         tile_window.col_off -= 1
@@ -61,6 +65,7 @@ def process_tile(tile):
         tile_window.height += 2
         tile_window = tile_window.round_offsets().round_shape()
 
+        # if no data in window, skip processing the tile
         if not src.read_masks(1, window=tile_window).any():
             return tile, None
 

--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -146,6 +146,9 @@ def mbtiles(ctx, files, output, force_overwrite, title, description,
         # Initialize the sqlite db.
         if os.path.exists(output):
             os.unlink(output)
+        # workaround for bug here: https://bugs.python.org/issue27126
+        sqlite3.connect(':memory:').close()
+
         conn = sqlite3.connect(output)
         cur = conn.cursor()
         cur.execute(

--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -21,7 +21,7 @@ from mbtiles import __version__ as mbtiles_version
 DEFAULT_NUM_WORKERS = cpu_count() - 1
 RESAMPLING_METHODS = [method.name for method in Resampling]
 
-TILES_CRS = "EPSG:3857"
+TILES_CRS = 'EPSG:3857'
 
 
 def validate_nodata(dst_nodata, src_nodata, meta_nodata):

--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -13,7 +13,6 @@ from rasterio.enums import Resampling
 from rasterio.rio.helpers import resolve_inout
 from rasterio.rio.options import force_overwrite_opt, output_opt
 from rasterio.warp import transform
-from rasterio.windows import get_data_window, from_bounds
 
 from mbtiles import buffer, init_worker, process_tile
 from mbtiles import __version__ as mbtiles_version
@@ -194,17 +193,9 @@ def mbtiles(ctx, files, output, force_overwrite, title, description,
             west, south, east, north, range(minzoom, maxzoom + 1))
 
         for tile, contents in pool.imap_unordered(process_tile, tiles):
-            ulx, uly = mercantile.xy(
-                       *mercantile.ul(tile.x, tile.y, tile.z))
-            lrx, lry = mercantile.xy(
-                       *mercantile.ul(tile.x + 1, tile.y + 1, tile.z))
-            with rasterio.open(inputfile) as src:
-                (wwest, weast), (wsouth, wnorth) = transform(
-                    TILES_CRS, src.crs, (ulx, lrx), (lry, uly))
-                tile_window = from_bounds(wwest, wsouth, weast, wnorth,
-                                          transform=src.transform)
-                if not src.read_masks(1, window=tile_window).astype('bool').any():
-                    continue
+
+            if tile is None:
+                continue
 
             # MBTiles has a different origin than Mercantile/tilebelt.
             tiley = int(math.pow(2, tile.z)) - tile.y - 1

--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -194,7 +194,8 @@ def mbtiles(ctx, files, output, force_overwrite, title, description,
 
         for tile, contents in pool.imap_unordered(process_tile, tiles):
 
-            if tile is None:
+            if contents is None:
+                logger.info("Tile %r is empty and will be skipped", tile)
                 continue
 
             # MBTiles has a different origin than Mercantile/tilebelt.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ cython==0.21.2
 enum34
 numpy>=1.10
 pytest
-rasterio>=1.0a2
+rasterio>=1.0a10
 snuggs>=1.2
 setuptools>=0.9.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ test_files = [
 
 
 def pytest_cmdline_main(config):
-    # Bail if the test raster data is not present. Test data is not 
+    # Bail if the test raster data is not present. Test data is not
     # distributed with sdists since 0.12.
     if reduce(operator.and_, map(os.path.exists, test_files)):
         print("Test data present.")
@@ -33,3 +33,14 @@ def data():
     for filename in test_files:
         shutil.copy(filename, str(tmpdir))
     return tmpdir
+
+
+@pytest.fixture(scope='function')
+def empty_data(tmpdir):
+    """A temporary directory containing a folder with an empty data file."""
+    filename = test_files[0]
+    out_filename = os.path.join(str(tmpdir), "empty.tif")
+    with rasterio.open(filename, 'r') as src:
+        with rasterio.open(out_filename, 'w', **src.meta) as dst:
+            pass
+    return out_filename

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,16 +145,16 @@ def test_export_bilinear(tmpdir, data):
     assert len(cur.fetchall()) == 6
 
 
-def test_skip_empty(tmpdir, data):
-    inputfile = str(data.join('RGB.byte.tif'))
+def test_skip_empty(tmpdir, empty_data):
+    """This file has the same shape as RGB.byte.tif, but no data."""
+    inputfile = empty_data
     outputfile = str(tmpdir.join('export.mbtiles'))
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['mbtiles', inputfile, outputfile, '--zoom-levels', '6..9'])
+        ['mbtiles', inputfile, outputfile])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
-    # there would be 32 tiles if empty tiles were not skipped
-    assert len(cur.fetchall()) == 26
+    assert len(cur.fetchall()) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,3 +143,18 @@ def test_export_bilinear(tmpdir, data):
     cur = conn.cursor()
     cur.execute("select * from tiles")
     assert len(cur.fetchall()) == 6
+
+
+def test_skip_empty(tmpdir, data):
+    inputfile = str(data.join('RGB.byte.tif'))
+    outputfile = str(tmpdir.join('export.mbtiles'))
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['mbtiles', inputfile, outputfile, '--zoom-levels', '6..9'])
+    assert result.exit_code == 0
+    conn = sqlite3.connect(outputfile)
+    cur = conn.cursor()
+    cur.execute("select * from tiles")
+    # there would be 32 tiles if empty tiles were not skipped
+    assert len(cur.fetchall()) == 26

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,10 +151,10 @@ def test_skip_empty(tmpdir, data):
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['mbtiles', inputfile, outputfile, '--zoom-levels', '6..9'])
+        ['mbtiles', inputfile, outputfile, '--zoom-levels', '6..10'])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
     # there would be 32 tiles if empty tiles were not skipped
-    assert len(cur.fetchall()) == 26
+    assert len(cur.fetchall()) == 67

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,10 +151,10 @@ def test_skip_empty(tmpdir, data):
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['mbtiles', inputfile, outputfile, '--zoom-levels', '6..10'])
+        ['mbtiles', inputfile, outputfile, '--zoom-levels', '6..9'])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
     # there would be 32 tiles if empty tiles were not skipped
-    assert len(cur.fetchall()) == 67
+    assert len(cur.fetchall()) == 26


### PR DESCRIPTION
This is a work in progress, but I've reached a point where I think feedback would be very useful.

I regularly am converting rasters that have significant areas of nodata into mbtiles, which motivates my desire to reduce time processing areas of nodata. The change submitted here is working well enough in terms of producing the right end results, at least on all cases I've tested upon. It successfully skips over regions with nodata, while producing an mbtiles file that looks the same. For tifs without any area of nodata, this appears to be 10-20% slower, with the `real` time difference somewhat smaller than the `user` time difference. As areas of nodata become more significant, this PR starts to become faster, with a turnover point around 30-40% nodata, unless the `--image-dump` option is set, in which case the turnover is earlier. It does depend somewhat on the `--zoom-level` range too.

The check for nodata in a tile currently happens outside the `process_tile` call. This leads to some duplicated logic in getting tile bounds. I wasn't sure of a clean way though to skip processing a tile after entering `process_tile` though, whereas putting it outside the call made it easy to skip over, but maybe I'm missing something obvious? I also wondered whether there might be a faster method of checking whether there is data within specified bounds of a raster.

I expect any implementation of this is probably going to be a little slower on tifs without nodata anywhere. Would an extra argument to enable this logic be reasonable, such that the user can decide whether to skip processing nodata regions? On the other hand, it still seems possible that implementing this differently would make the speed difference negligible on a raster that doesn't have any region of nodata, and it is obviously desirable to avoid adding an argument whose purpose would be obscure to most users, and for which the fastest setting would probably not be obvious to anyone.