### PR TITLE
Skip tiles with no data

### DIFF
--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -49,7 +49,7 @@ def process_tile(tile):
     src_nodata = kwds.pop('src_nodata', None)
     dst_nodata = kwds.pop('dst_nodata', None)
 
-    # Reproject into a GeoTIFF tile.
+    # Reproject into a JPEG or PNG tile.
     with MemoryFile() as memdst:
         with memdst.open(**kwds) as tiledst:
             reproject(

--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -94,7 +94,7 @@ def mbtiles(ctx, files, output, force_overwrite, title, description,
                                   force_overwrite=force_overwrite)
     inputfile = files[0]
 
-    logger = logging.getLogger('rio-mbtiles')
+    logger = logging.getLogger(__name__)
 
     with ctx.obj['env']:
 
@@ -191,6 +191,10 @@ def mbtiles(ctx, files, output, force_overwrite, title, description,
             west, south, east, north, range(minzoom, maxzoom + 1))
 
         for tile, contents in pool.imap_unordered(process_tile, tiles):
+
+            if contents is None:
+                logger.info("Tile %r is empty and will be skipped", tile)
+                continue
 
             # MBTiles has a different origin than Mercantile/tilebelt.
             tiley = int(math.pow(2, tile.z)) - tile.y - 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ def test_export_tiles(tmpdir, data):
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
-    assert len(cur.fetchall()) == 6
+    assert len(cur.fetchall()) == 5
 
 
 def test_export_zoom(tmpdir, data):
@@ -90,7 +90,7 @@ def test_export_zoom(tmpdir, data):
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
-    assert len(cur.fetchall()) == 6
+    assert len(cur.fetchall()) == 5
 
 
 def test_export_jobs(tmpdir, data):
@@ -103,7 +103,7 @@ def test_export_jobs(tmpdir, data):
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
-    assert len(cur.fetchall()) == 6
+    assert len(cur.fetchall()) == 5
 
 
 def test_export_src_nodata(tmpdir, data):
@@ -116,7 +116,7 @@ def test_export_src_nodata(tmpdir, data):
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
-    assert len(cur.fetchall()) == 6
+    assert len(cur.fetchall()) == 5
 
 
 def test_export_dump(tmpdir, data):
@@ -128,7 +128,7 @@ def test_export_dump(tmpdir, data):
         main_group,
         ['mbtiles', inputfile, outputfile, '--image-dump', str(dumpdir)])
     assert result.exit_code == 0
-    assert len(os.listdir(str(dumpdir))) == 6
+    assert len(os.listdir(str(dumpdir))) == 5
 
 
 def test_export_bilinear(tmpdir, data):
@@ -142,4 +142,4 @@ def test_export_bilinear(tmpdir, data):
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()
     cur.execute("select * from tiles")
-    assert len(cur.fetchall()) == 6
+    assert len(cur.fetchall()) == 5


### PR DESCRIPTION
We detect tiles with no valid data by checking a mask of an in-memory temp dataset.