### PR TITLE
Add resampling options to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,9 @@ Usage
       -j INTEGER              Number of worker processes (default: 3).
       --src-nodata FLOAT      Manually override source nodata
       --dst-nodata FLOAT      Manually override destination nodata
+      --resampling            Resampling method to use. Options within
+                              rasterio.enums.Resampling are supported.
+                              (default: nearest)
       --version               Show the version and exit.
       --help                  Show this message and exit.
 


### PR DESCRIPTION
The full list of options is a little unwieldy, so I thought for the
purposes of just showing it as an option for someone checking out
rio-mbtiles on github, a little extra explanation rather than the full
listing might be more valuable.