### PR TITLE
add mercantile to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ cligj
 coveralls>=0.4
 cython==0.21.2
 enum34
+mercantile
 numpy>=1.10
 pytest
 rasterio>=1.0a2


### PR DESCRIPTION
It is listed on pypi as a requirement (which seems to account for `mercantile` being installed in the travis build), but since it is missing from the requirements file, there's an extra step required to get an environment set up locally.