### PR TITLE
Enhancements mainly to single-band input/output files

### DIFF
--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -77,6 +77,8 @@ def process_tile(tile):
                 # if no data in window, skip processing the tile
                 if not src.read_masks(1, window=tile_window).any():
                     return tile, None
+                if src_nodata is not None and (src.read(1, window=tile_window) == src_nodata).all():
+                    return tile, None
 
             except ValueError:
                 log.info("Tile %r will not be skipped, even if empty. This is harmless.", tile)

--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -57,6 +57,7 @@ def process_tile(tile):
                                               kwds['width'], kwds['height'])
     src_nodata = kwds.pop('src_nodata', None)
     dst_nodata = kwds.pop('dst_nodata', None)
+    colormap = kwds.pop('colormap', None)
 
     warnings.simplefilter('ignore')
 
@@ -82,6 +83,9 @@ def process_tile(tile):
 
             except ValueError:
                 log.info("Tile %r will not be skipped, even if empty. This is harmless.", tile)
+
+            if colormap is not None:
+                tmp.write_colormap(1, colormap)
 
             reproject(rasterio.band(src, tmp.indexes),
                       rasterio.band(tmp, tmp.indexes),


### PR DESCRIPTION
I added some extra features that I needed:
- Support for single-band input images (now supports 1..4 bands, in theory PNG can support gray+alpha for bands==2). This replaces the `--rgba` option with `--bands N` for N=1..4
- Colormap support for 8-bit PNGs
- Skipping tiles which only have `src_nodata` as values
