### PR TITLE
Use physical CPU cores for N-workers

### DIFF
--- a/mbtiles/scripts/cli.py
+++ b/mbtiles/scripts/cli.py
@@ -2,12 +2,13 @@
 
 import logging
 import math
-from multiprocessing import cpu_count, Pool
+from multiprocessing import Pool
 import os
 import sqlite3
 
 import click
 import mercantile
+import psutil
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.rio.helpers import resolve_inout
@@ -18,7 +19,10 @@ from mbtiles import init_worker, process_tile
 from mbtiles import __version__ as mbtiles_version
 
 
-DEFAULT_NUM_WORKERS = cpu_count() - 1
+#: physical cores (at least 1, or N cores - 1)
+cpu_cores = max(1, psutil.cpu_count(logical=False) - 1)
+
+DEFAULT_NUM_WORKERS = cpu_cores
 RESAMPLING_METHODS = [method.name for method in Resampling]
 
 TILES_CRS = 'EPSG:3857'

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='rio-mbtiles',
           'click',
           'mercantile',
           'numpy>=1.10',
+          'psutil',
           'rasterio~=1.0'
       ],
       extras_require={


### PR DESCRIPTION
Small PR to address a minor point noted in #51 
- python on hyperthreaded cores may drop in performance vs. physical cores