### PR TITLE
Fix thread-safety on SQLite

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,7 +96,7 @@ def test_export_jobs(tmpdir, data):
     outputfile = str(tmpdir.join('export.mbtiles'))
     runner = CliRunner()
     result = runner.invoke(
-        main_group, ['mbtiles', inputfile, outputfile, '-j', '4'])
+        main_group, ['mbtiles', inputfile, outputfile])  #, '-j', '4'])
     assert result.exit_code == 0
     conn = sqlite3.connect(outputfile)
     cur = conn.cursor()


### PR DESCRIPTION
Fix #51 for thread-safety on SQLite by using a single thread.  The CLI is not backwards compatible, due to removal of the `-j` option, but otherwise it's a simple changeset.