### PR TITLE
Use a semaphore for sqlite writes

### DIFF
--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -14,6 +14,7 @@ import rasterio
 __version__ = '1.4.2'
 
 base_kwds = None
+resampling = None
 src = None
 
 TILES_CRS = 'EPSG:3857'


### PR DESCRIPTION
Related to #51 

Just in case some deadlocks might be related to access to sqlite, wrap the tile data writes in a semaphore.  (Replaces #53 without removing multiprocessing; hasn't been tested on larger inputs where occasional dead locks are found, so dead-locks might still occur if they are somehow related to contention over reading the global `src` data or running short on memory while processing tiles.)

Adds outputs of an empty tile-record for tiles with no src-data, since `mbview` crashes when src is totally empty of all data (something about max_zoom is not defined).