### PR TITLE
Add --oo (open) and --wo (warp) options like in gdalwarp

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changes
 1.5b2 (2020-10-15)
 ------------------
 
+- Add --oo (open) options and --wo (warp) options like those of gdalwarp. These
+  allow control over, for example, overview level of TMS datasets and the
+  number of threads used internally by GDAL's warper.
 - Add a --cutline option that takes an optional path to a GeoJSON
   FeatureCollection (#62). No pixels outside the cutline shape(s) will be
   exported and no tiles outside the cutline will be generated.

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,14 @@ Usage
 									  used as a cutline. Only source pixels within
 									  the cutline features will be exported.
 
+	  --oo NAME=VALUE                 Format driver-specific options to be used
+									  when accessing the input dataset. See the
+									  GDAL format driver documentation for more
+									  information.
+
+	  --wo NAME=VALUE                 See the GDAL warp options documentation for
+									  more information.
+
 	  --help                          Show this message and exit.
 
 Performance

--- a/README.rst
+++ b/README.rst
@@ -14,79 +14,79 @@ Usage
 
 .. code-block:: console
 
-	$ rio mbtiles --help
-	Usage: rio mbtiles [OPTIONS] INPUT [OUTPUT]
+    $ rio mbtiles --help
+    Usage: rio mbtiles [OPTIONS] INPUT [OUTPUT]
 
-	  Export a dataset to MBTiles (version 1.1) in a SQLite file.
+      Export a dataset to MBTiles (version 1.1) in a SQLite file.
 
-	  The input dataset may have any coordinate reference system. It must have
-	  at least three bands, which will be become the red, blue, and green bands
-	  of the output image tiles.
+      The input dataset may have any coordinate reference system. It must have
+      at least three bands, which will be become the red, blue, and green bands
+      of the output image tiles.
 
-	  An optional fourth alpha band may be copied to the output tiles by using
-	  the --rgba option in combination with the PNG format. This option requires
-	  that the input dataset has at least 4 bands.
+      An optional fourth alpha band may be copied to the output tiles by using
+      the --rgba option in combination with the PNG format. This option requires
+      that the input dataset has at least 4 bands.
 
-	  If no zoom levels are specified, the defaults are the zoom levels nearest
-	  to the one at which one tile may contain the entire source dataset.
+      If no zoom levels are specified, the defaults are the zoom levels nearest
+      to the one at which one tile may contain the entire source dataset.
 
-	  If a title or description for the output file are not provided, they will
-	  be taken from the input dataset's filename.
+      If a title or description for the output file are not provided, they will
+      be taken from the input dataset's filename.
 
-	  This command is suited for small to medium (~1 GB) sized sources.
+      This command is suited for small to medium (~1 GB) sized sources.
 
-	  Python package: rio-mbtiles (https://github.com/mapbox/rio-mbtiles).
+      Python package: rio-mbtiles (https://github.com/mapbox/rio-mbtiles).
 
-	Options:
-	  -o, --output PATH               Path to output file (optional alternative to
-									  a positional arg).
+    Options:
+      -o, --output PATH               Path to output file (optional alternative to
+                                      a positional arg).
 
-	  --append                        Append tiles to an existing file.
-	  --overwrite                     Always overwrite an existing output file.
-	  --title TEXT                    MBTiles dataset title.
-	  --description TEXT              MBTiles dataset description.
-	  --overlay                       Export as an overlay (the default).
-	  --baselayer                     Export as a base layer.
-	  -f, --format [JPEG|PNG]         Tile image format.
-	  --tile-size INTEGER             Width and height of individual square tiles
-									  to create.  [default: 256]
+      --append                        Append tiles to an existing file.
+      --overwrite                     Always overwrite an existing output file.
+      --title TEXT                    MBTiles dataset title.
+      --description TEXT              MBTiles dataset description.
+      --overlay                       Export as an overlay (the default).
+      --baselayer                     Export as a base layer.
+      -f, --format [JPEG|PNG]         Tile image format.
+      --tile-size INTEGER             Width and height of individual square tiles
+                                      to create.  [default: 256]
 
-	  --zoom-levels MIN..MAX          A min...max range of export zoom levels. The
-									  default zoom level is the one at which the
-									  dataset is contained within a single tile.
+      --zoom-levels MIN..MAX          A min...max range of export zoom levels. The
+                                      default zoom level is the one at which the
+                                      dataset is contained within a single tile.
 
-	  --image-dump PATH               A directory into which image tiles will be
-									  optionally dumped.
+      --image-dump PATH               A directory into which image tiles will be
+                                      optionally dumped.
 
-	  -j INTEGER                      Number of workers (default: number of
-									  computer's processors).
+      -j INTEGER                      Number of workers (default: number of
+                                      computer's processors).
 
-	  --src-nodata FLOAT              Manually override source nodata
-	  --dst-nodata FLOAT              Manually override destination nodata
-	  --resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss|max|min|med|q1|q3]
-									  Resampling method to use.  [default:
-									  nearest]
+      --src-nodata FLOAT              Manually override source nodata
+      --dst-nodata FLOAT              Manually override destination nodata
+      --resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss|max|min|med|q1|q3]
+                                      Resampling method to use.  [default:
+                                      nearest]
 
-	  --version                       Show the version and exit.
-	  --rgba                          Select RGBA output. For PNG only.
-	  --implementation [cf|mp]        Concurrency implementation. Use
-									  concurrent.futures (cf) or multiprocessing
-									  (mp).
+      --version                       Show the version and exit.
+      --rgba                          Select RGBA output. For PNG only.
+      --implementation [cf|mp]        Concurrency implementation. Use
+                                      concurrent.futures (cf) or multiprocessing
+                                      (mp).
 
-	  -#, --progress-bar              Display progress bar.
-	  --cutline PATH                  Path to a GeoJSON FeatureCollection to be
-									  used as a cutline. Only source pixels within
-									  the cutline features will be exported.
+      -#, --progress-bar              Display progress bar.
+      --cutline PATH                  Path to a GeoJSON FeatureCollection to be
+                                      used as a cutline. Only source pixels within
+                                      the cutline features will be exported.
 
-	  --oo NAME=VALUE                 Format driver-specific options to be used
-									  when accessing the input dataset. See the
-									  GDAL format driver documentation for more
-									  information.
+      --oo NAME=VALUE                 Format driver-specific options to be used
+                                      when accessing the input dataset. See the
+                                      GDAL format driver documentation for more
+                                      information.
 
-	  --wo NAME=VALUE                 See the GDAL warp options documentation for
-									  more information.
+      --wo NAME=VALUE                 See the GDAL warp options documentation for
+                                      more information.
 
-	  --help                          Show this message and exit.
+      --help                          Show this message and exit.
 
 Performance
 -----------

--- a/mbtiles/cf.py
+++ b/mbtiles/cf.py
@@ -1,4 +1,4 @@
-# concurrent.futures implementation
+"""concurrent.futures implementation"""
 
 import concurrent.futures
 from itertools import islice
@@ -23,14 +23,15 @@ def process_tiles(
     img_ext=None,
     image_dump=None,
     progress_bar=None,
-    **warp_options,
+    open_options=None,
+    warp_options=None,
 ):
     """Warp imagery into tiles and commit to mbtiles database.
     """
     with concurrent.futures.ProcessPoolExecutor(
         max_workers=num_workers,
         initializer=init_worker,
-        initargs=(inputfile, base_kwds, resampling, warp_options),
+        initargs=(inputfile, base_kwds, resampling, open_options, warp_options),
     ) as executor:
         group = islice(tiles, BATCH_SIZE)
         futures = {executor.submit(process_tile, tile) for tile in group}

--- a/mbtiles/mp.py
+++ b/mbtiles/mp.py
@@ -1,4 +1,4 @@
-# multiprocessing Pool implementation
+"""multiprocessing Pool implementation"""
 
 from multiprocessing import Pool
 import warnings
@@ -27,14 +27,15 @@ def process_tiles(
     img_ext=None,
     image_dump=None,
     progress_bar=None,
-    **warp_options
+    open_options=None,
+    warp_options=None,
 ):
     """Warp raster into tiles and commit tiles to mbtiles database.
     """
     pool = Pool(
         num_workers,
         init_worker,
-        (inputfile, base_kwds, resampling, warp_options),
+        (inputfile, base_kwds, resampling, open_options, warp_options),
         100 * BATCH_SIZE,
     )
 

--- a/mbtiles/worker.py
+++ b/mbtiles/worker.py
@@ -12,10 +12,6 @@ from rasterio.windows import from_bounds as window_from_bounds
 import mercantile
 import rasterio
 
-
-# base_kwds = None
-# src = None
-
 TILES_CRS = "EPSG:3857"
 
 log = logging.getLogger(__name__)

--- a/mbtiles/worker.py
+++ b/mbtiles/worker.py
@@ -1,3 +1,5 @@
+"""rio-mbtiles processing worker"""
+
 import logging
 import warnings
 
@@ -11,20 +13,21 @@ import mercantile
 import rasterio
 
 
-base_kwds = None
-src = None
+# base_kwds = None
+# src = None
 
 TILES_CRS = "EPSG:3857"
 
 log = logging.getLogger(__name__)
 
 
-def init_worker(path, profile, resampling_method, kwds):
-    global base_kwds, filename, resampling, warp_options
+def init_worker(path, profile, resampling_method, open_opts, warp_opts):
+    global base_kwds, filename, resampling, open_options, warp_options
     resampling = Resampling[resampling_method]
     base_kwds = profile.copy()
     filename = path
-    warp_options = kwds.copy() if kwds is not None else {}
+    open_options = open_opts.copy() if open_opts is not None else {}
+    warp_options = warp_opts.copy() if warp_opts is not None else {}
 
 
 def process_tile(tile):
@@ -45,64 +48,66 @@ def process_tile(tile):
         Image bytes corresponding to the tile.
 
     """
-    global base_kwds, resampling, filename, warp_options
+    global base_kwds, resampling, filename, open_options, warp_options
 
-    src = rasterio.open(filename)
+    with rasterio.open(filename, **open_options) as src:
 
-    # Get the bounds of the tile.
-    ulx, uly = mercantile.xy(*mercantile.ul(tile.x, tile.y, tile.z))
-    lrx, lry = mercantile.xy(*mercantile.ul(tile.x + 1, tile.y + 1, tile.z))
+        # Get the bounds of the tile.
+        ulx, uly = mercantile.xy(*mercantile.ul(tile.x, tile.y, tile.z))
+        lrx, lry = mercantile.xy(*mercantile.ul(tile.x + 1, tile.y + 1, tile.z))
 
-    kwds = base_kwds.copy()
-    kwds["transform"] = transform_from_bounds(
-        ulx, lry, lrx, uly, kwds["width"], kwds["height"]
-    )
-    src_nodata = kwds.pop("src_nodata", None)
-    dst_nodata = kwds.pop("dst_nodata", None)
+        kwds = base_kwds.copy()
+        kwds["transform"] = transform_from_bounds(
+            ulx, lry, lrx, uly, kwds["width"], kwds["height"]
+        )
+        src_nodata = kwds.pop("src_nodata", None)
+        dst_nodata = kwds.pop("dst_nodata", None)
 
-    warnings.simplefilter("ignore")
+        warnings.simplefilter("ignore")
 
-    log.info("Reprojecting tile: tile=%r", tile)
+        log.info("Reprojecting tile: tile=%r", tile)
 
-    with MemoryFile() as memfile:
+        with MemoryFile() as memfile:
 
-        with memfile.open(**kwds) as tmp:
+            with memfile.open(**kwds) as tmp:
 
-            # determine window of source raster corresponding to the tile
-            # image, with small buffer at edges
-            try:
-                west, south, east, north = transform_bounds(
-                    TILES_CRS, src.crs, ulx, lry, lrx, uly
+                # determine window of source raster corresponding to the tile
+                # image, with small buffer at edges
+                try:
+                    west, south, east, north = transform_bounds(
+                        TILES_CRS, src.crs, ulx, lry, lrx, uly
+                    )
+                    tile_window = window_from_bounds(
+                        west, south, east, north, transform=src.transform
+                    )
+                    adjusted_tile_window = Window(
+                        tile_window.col_off - 1,
+                        tile_window.row_off - 1,
+                        tile_window.width + 2,
+                        tile_window.height + 2,
+                    )
+                    tile_window = adjusted_tile_window.round_offsets().round_shape()
+
+                    # if no data in window, skip processing the tile
+                    if not src.read_masks(1, window=tile_window).any():
+                        return tile, None
+
+                except ValueError:
+                    log.info(
+                        "Tile %r will not be skipped, even if empty. This is harmless.",
+                        tile,
+                    )
+
+                num_threads = int(warp_options.pop("num_threads", 2))
+
+                reproject(
+                    rasterio.band(src, tmp.indexes),
+                    rasterio.band(tmp, tmp.indexes),
+                    src_nodata=src_nodata,
+                    dst_nodata=dst_nodata,
+                    num_threads=num_threads,
+                    resampling=resampling,
+                    **warp_options
                 )
-                tile_window = window_from_bounds(
-                    west, south, east, north, transform=src.transform
-                )
-                adjusted_tile_window = Window(
-                    tile_window.col_off - 1,
-                    tile_window.row_off - 1,
-                    tile_window.width + 2,
-                    tile_window.height + 2,
-                )
-                tile_window = adjusted_tile_window.round_offsets().round_shape()
 
-                # if no data in window, skip processing the tile
-                if not src.read_masks(1, window=tile_window).any():
-                    return tile, None
-
-            except ValueError:
-                log.info(
-                    "Tile %r will not be skipped, even if empty. This is harmless.",
-                    tile,
-                )
-
-            reproject(
-                rasterio.band(src, tmp.indexes),
-                rasterio.band(tmp, tmp.indexes),
-                src_nodata=src_nodata,
-                dst_nodata=dst_nodata,
-                num_threads=2,
-                resampling=resampling,
-                **warp_options
-            )
-
-        return tile, memfile.read()
+            return tile, memfile.read()

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -23,6 +23,7 @@ def test_process_tile(data, filename, tile):
         },
         "nearest",
         {},
+        {},
     )
     t, contents = mbtiles.worker.process_tile(tile)
     assert t.x == tile.x


### PR DESCRIPTION
Add --oo (open) options and --wo (warp) options like those of gdalwarp. These allow control over, for example, overview level of TMS datasets and the number of threads used internally by GDAL's warper.