### PR TITLE
Append overwrite

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changes
 =======
 
+1.5b4 (2020-10-29)
+------------------
+
+- Consolidate --append/--overwrite into one option and make appending the
+  default.
+
 1.5b3 (2020-10-28)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,9 @@ Usage
       -o, --output PATH               Path to output file (optional alternative to
                                       a positional arg).
 
-      --append                        Append tiles to an existing file.
-      --overwrite                     Always overwrite an existing output file.
+      --append / --overwrite          Append tiles to an existing file or
+                                      overwrite.
+
       --title TEXT                    MBTiles dataset title.
       --description TEXT              MBTiles dataset description.
       --overlay                       Export as an overlay (the default).
@@ -74,6 +75,7 @@ Usage
                                       (mp).
 
       -#, --progress-bar              Display progress bar.
+      --covers TEXT                   Restrict mbtiles output to cover a quadkey
       --cutline PATH                  Path to a GeoJSON FeatureCollection to be
                                       used as a cutline. Only source pixels within
                                       the cutline features will be exported.

--- a/mbtiles/__init__.py
+++ b/mbtiles/__init__.py
@@ -3,7 +3,7 @@
 import sys
 import warnings
 
-__version__ = "1.5b3"
+__version__ = "1.5b4"
 
 if sys.version_info < (3, 7):
     warnings.warn(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -378,15 +378,6 @@ def test_appending_export_count(
     assert len(results) == exp_num_tiles
 
 
-def test_mutually_exclusive_operations():
-    """--overwrite and --append are mutually exclusive"""
-    runner = CliRunner()
-    result = runner.invoke(
-        main_group, ["mbtiles", "--append", "--overwrite", "foo.tif", "foo.mbtiles"]
-    )
-    assert result.exit_code == 2
-
-
 @pytest.mark.parametrize("inputfiles", [[], ["a.tif", "b.tif"]])
 def test_input_required(inputfiles):
     """We require exactly one input file"""


### PR DESCRIPTION
Consolidate `--append/--overwrite` into one option, eliminating some validation code. Appending is the default.