### PR TITLE
Add `--scheme` option

### DIFF
--- a/mbtiles/cf.py
+++ b/mbtiles/cf.py
@@ -22,6 +22,7 @@ def process_tiles(
     resampling=None,
     img_ext=None,
     image_dump=None,
+    tile_scheme=None,
     progress_bar=None,
     open_options=None,
     warp_options=None,
@@ -60,7 +61,7 @@ def process_tiles(
 
             for future in done:
                 tile, contents = future.result()
-                insert_results(tile, contents, img_ext=img_ext, image_dump=image_dump)
+                insert_results(tile, contents, img_ext=img_ext, image_dump=image_dump, tile_scheme=tile_scheme)
 
             count += len(done)
             if count > BATCH_SIZE:

--- a/mbtiles/mp.py
+++ b/mbtiles/mp.py
@@ -26,6 +26,7 @@ def process_tiles(
     resampling=None,
     img_ext=None,
     image_dump=None,
+    tile_scheme=None,
     progress_bar=None,
     open_options=None,
     warp_options=None,
@@ -62,7 +63,7 @@ def process_tiles(
             if item is None:
                 break
             tile, contents = item
-            insert_results(tile, contents, img_ext=img_ext, image_dump=image_dump)
+            insert_results(tile, contents, img_ext=img_ext, image_dump=image_dump, tile_scheme=tile_scheme)
 
         commit_mbtiles()
 


### PR DESCRIPTION
It defines the tiles' naming scheme as described in https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster-scheme.

@jqtrde Please review if you have the chance. Thanks.